### PR TITLE
Add bodydiv to block-classes, unwrap bodydiv element.

### DIFF
--- a/docx/word/document.topic.xsl
+++ b/docx/word/document.topic.xsl
@@ -75,6 +75,10 @@
     <xsl:apply-templates select="*"/>
   </xsl:template>
 
+  <xsl:template match="*[contains(@class, ' topic/bodydiv ')]" name="bodydiv">
+    <xsl:apply-templates select="*"/>
+  </xsl:template>
+  
   <xsl:template match="*[contains(@class, ' topic/abstract ')]" name="abstract">
     <xsl:apply-templates select="*"/>
   </xsl:template>

--- a/docx/word/flatten.xsl
+++ b/docx/word/flatten.xsl
@@ -33,6 +33,7 @@
   
   <xsl:variable name="x:is-block-classes" as="xs:string*" select="(
     ' topic/body ',
+    ' topic/bodydiv ',
     ' topic/shortdesc ',
     ' topic/abstract ',
     ' topic/title ',


### PR DESCRIPTION
The transform was failing when troubleshooting topics were processed. The cause was that the troubleSolution element (@class="- topic/bodydiv troubleshooting/troubleSolution ") was being processed as a paragraph rather than as a block. This pull request adds bodydiv to the list of recognized block classes, and it unwraps bodydiv during topic rendering.