### PR TITLE
ISO 8601

### DIFF
--- a/docx/word/comments.xsl
+++ b/docx/word/comments.xsl
@@ -78,7 +78,7 @@
         </xsl:attribute>
       </xsl:if>
       <xsl:if test="$attributes/@timestamp">
-        <xsl:attribute name="w:date" select="x:iso-dateTime(x:parse-dateTime(replace($attributes/@timestamp, '(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})([-+]\d{4}|Z)', '$1-$2-$3T$4:$5:$6$7')))"/>
+        <xsl:attribute name="w:date" select="x:iso-dateTime(x:parse-dateTime(replace($attributes/@timestamp, '(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})(([-+](\d{2})(\d{2}))|Z)', '$1-$2-$3T$4:$5:$6$7')))"/>
       </xsl:if>
       <w:p>
         <w:pPr>


### PR DESCRIPTION
* TZ as a UTC offset is this format: 2017-11-28T20:43:12+10:30 and not
  this: 2017-11-28T20:43:12+1030 (that's current Adelaide timezone,
  BTW, just to prove there are annoying, real world examples).
* This *should* fix the output format of the XSLT.