### PR TITLE
Add templates for line-through and tt elements

### DIFF
--- a/docx/word/document.hi-d.xsl
+++ b/docx/word/document.hi-d.xsl
@@ -36,5 +36,9 @@
   <xsl:template match="*[contains(@class, ' hi-d/sub ')]" mode="inline-style">
     <w:vertAlign w:val="subscript"/>
   </xsl:template>
+  
+  <xsl:template match="*[contains(@class, ' hi-d/line-through ')]" mode="inline-style">
+    <w:strike/>
+  </xsl:template>
     
 </xsl:stylesheet>

--- a/docx/word/document.hi-d.xsl
+++ b/docx/word/document.hi-d.xsl
@@ -40,5 +40,9 @@
   <xsl:template match="*[contains(@class, ' hi-d/line-through ')]" mode="inline-style">
     <w:strike/>
   </xsl:template>
+  
+  <xsl:template match="*[contains(@class, ' hi-d/tt ')]" mode="inline-style">
+    <w:rFonts w:ascii="Courier New" w:hAnsi="Courier New" w:cs="Courier New"/>
+  </xsl:template>
     
 </xsl:stylesheet>


### PR DESCRIPTION
Templates for `<line-through>` and `<tt>` were missing from the document.hi-d.xsl file. The commits on this pull request add the templates for both of these elements.